### PR TITLE
set cuda error to string

### DIFF
--- a/memory_opt/memoryOpt.h
+++ b/memory_opt/memoryOpt.h
@@ -18,7 +18,7 @@ template <typename T> void check(T result, char const *const func, const char *c
 {
     if (result) {
         fprintf(stderr, "CUDA error at %s:%d code=%d(%s) \"%s\" \n", file, line, static_cast<unsigned int>(result),
-                result, func);
+                cudaGetErrorString(result), func);
         exit(EXIT_FAILURE);
     }
 }


### PR DESCRIPTION
when cuda error occur, it will cause "Segmentation fault ", for the "result" value maybe unsigned-int(36)