### PR TITLE
make sure the programmer can be rerun

### DIFF
--- a/memory_opt/zeroCopy.cu
+++ b/memory_opt/zeroCopy.cu
@@ -115,7 +115,10 @@ float vectorAddViaZeroCopy(const unsigned int numElements, const unsigned int it
     int threadsPerBlock = 256;
     int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
 
-    checkCudaErrors(cudaSetDeviceFlags(cudaDeviceMapHost));
+    // If the current device has been set, recall will fail with the error cudaErrorSetOnActiveProcess.
+    cudaSetDeviceFlags(cudaDeviceMapHost);
+    cudaGetLastError();
+    
     // Allocate the host input vector A, B, C
     float *h_A = NULL;
     float *h_B = NULL;


### PR DESCRIPTION
If the current device has been set, recall cudaSetDeviceFlags(cudaDeviceMapHost) will fail with the error cudaErrorSetOnActiveProcess.