### PR TITLE
fix cublasStatus_t issue #4

### DIFF
--- a/matrix_multiply/Makefile
+++ b/matrix_multiply/Makefile
@@ -195,7 +195,7 @@ LIBRARIES :=
 ifeq ($(TARGET_ARCH),$(filter $(TARGET_ARCH),armv7l aarch64 sbsa))
 SMS ?= 53 61 70 72 75 80 86 87
 else
-SMS ?= 35 37 50 52 60 61 70 75
+SMS ?= 50 52 60 61 70 75
 endif
 
 ifeq ($(SMS),)

--- a/matrix_multiply/matMul.h
+++ b/matrix_multiply/matMul.h
@@ -15,6 +15,14 @@
 #define STRNCASECMP strncasecmp
 #endif
 
+#define checkCuBLASErrors(status) \
+    do { \
+        if (status != CUBLAS_STATUS_SUCCESS) { \
+            fprintf(stderr, "CUBLAS error: %d at %s:%d\n", status, __FILE__, __LINE__); \
+            exit(EXIT_FAILURE); \
+        } \
+    } while (0)
+
 template <typename T> void check(T result, char const *const func, const char *const file, int const line)
 {
     if (result) {

--- a/matrix_multiply/matMulCublasKernel.cu
+++ b/matrix_multiply/matMulCublasKernel.cu
@@ -54,11 +54,11 @@ int MatMulCublasTest(int argc, char **argv, int blockSize, int iterNum, const di
     const float alpha = 1.0f;
     const float beta = 0.0f;
     cublasHandle_t handle;
-    checkCudaErrors(cublasCreate(&handle));
-    
+    checkCuBLASErrors(cublasCreate(&handle));
+
     // Create and start timer
     printf("Computing result using CUBLAS Sgemmm Kernel. \n");
-    checkCudaErrors(cublasSgemm(
+    checkCuBLASErrors(cublasSgemm(
         handle, CUBLAS_OP_N, CUBLAS_OP_N, dimsB.x, dimsA.y,
         dimsA.x, &alpha, d_B, dimsB.x, d_A,
         dimsA.x, &beta, d_C, dimsB.x));
@@ -73,7 +73,7 @@ int MatMulCublasTest(int argc, char **argv, int blockSize, int iterNum, const di
     for (int j = 0; j < iterNum; j++) {
       // note cublas is column primary!
       // need to transpose the order
-      checkCudaErrors(cublasSgemm(
+      checkCuBLASErrors(cublasSgemm(
           handle, CUBLAS_OP_N, CUBLAS_OP_N, dimsB.x, dimsA.y,
           dimsA.x, &alpha, d_B, dimsB.x, d_A,
           dimsA.x, &beta, d_C, dimsB.x));
@@ -99,7 +99,7 @@ int MatMulCublasTest(int argc, char **argv, int blockSize, int iterNum, const di
     // Copy result from device to host
     checkCudaErrors(cudaMemcpyAsync(h_C, d_C, mem_size_C, cudaMemcpyDeviceToHost, stream));
     checkCudaErrors(cudaStreamSynchronize(stream));
-    checkCudaErrors(cublasDestroy(handle));
+    checkCuBLASErrors(cublasDestroy(handle));
 
     bool ret = ResultCheck(h_C, static_cast<int>(dimsC.x * dimsC.y), dimsA.x, valB);
 


### PR DESCRIPTION
1. While CUDA version is higher than 11.x  could raise error: argument of type "cublasStatus_t" is incompatible with parameter of type "cudaError_t".
2.  Delete 37 arch in makefile for cublas case.